### PR TITLE
Add option to run with a plugin

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -50,6 +50,10 @@ module Configuration
       Pathname.new(env('AGENTS_INSTALL_DIR', '.')) + 'go-agents'
     end
 
+    def plugin_src_dir
+      Pathname.new(env('PLUGIN_SRC_DIR', ''))
+    end
+
     def tools_dir
       Pathname.new(env('TOOLS_DIR', './tools'))
     end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -53,6 +53,10 @@ module Configuration
       Pathname.new(env('AGENTS_INSTALL_DIR', '.')) + 'go-agents'
     end
 
+    def include_plugin
+      Pathname.new(env('INCLUDE_PLUGIN', 'N'))
+    end
+
     def plugin_src_dir
       Pathname.new(env('PLUGIN_SRC_DIR', ''))
     end

--- a/lib/downloader.rb
+++ b/lib/downloader.rb
@@ -37,7 +37,7 @@ class Downloader
       uri = URI.parse(download[:url])
       file, path = extract_file_and_path(download[:url])
 
-      print "Downloading #{file}"
+      print "Downloading #{file} from #{uri}"
       File.open(path, 'w+') do |f|
         IO.copy_stream(open(uri, 'rb'), f)
       end

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -24,7 +24,7 @@ namespace :server do
     }
 
     mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"
-    cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
+    # cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
 
   end
 

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -23,8 +23,10 @@ namespace :server do
       f.extract_to("#{server_dir}")
     }
 
-    mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"
-    # cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
+    if (setup.include_plugin == 'Y')
+      mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"
+      cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
+    end
 
   end
 

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -23,7 +23,6 @@ namespace :server do
       f.extract_to("#{server_dir}")
     }
 
-    puts "Should we be including the plugin: #{setup.include_plugin}"
     if setup.include_plugin.to_s == 'Y'
       puts 'Copying the plugin'
       mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -24,7 +24,7 @@ namespace :server do
     }
 
     mkdir_p "#{server_dir}/plugins/external/"
-    cp "#{setup.plugin_src_dir}", "#{server_dir}/plugins/external/"
+    cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
 
   end
 

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -23,7 +23,7 @@ namespace :server do
       f.extract_to("#{server_dir}")
     }
 
-    mkdir_p "#{server_dir}/plugins/external/"
+    mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"
     cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
 
   end

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -23,6 +23,7 @@ namespace :server do
       f.extract_to("#{server_dir}")
     }
 
+    mkdir_p "#{server_dir}/plugins/external/"
     cp "#{setup.plugin_src_dir}", "#{server_dir}/plugins/external/"
 
   end

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -24,7 +24,7 @@ namespace :server do
     }
 
     puts "Should we be including the plugin: #{setup.include_plugin}"
-    if (setup.include_plugin == 'Y')
+    if setup.include_plugin.to_s == 'Y'
       puts 'Copying the plugin'
       mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"
       cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -23,6 +23,8 @@ namespace :server do
       f.extract_to("#{server_dir}")
     }
 
+    cp "#{setup.plugin_src_dir}", "#{server_dir}/plugins/external/"
+
   end
 
   task :start => 'server:stop' do

--- a/rakelib/server.rake
+++ b/rakelib/server.rake
@@ -23,7 +23,9 @@ namespace :server do
       f.extract_to("#{server_dir}")
     }
 
+    puts "Should we be including the plugin: #{setup.include_plugin}"
     if (setup.include_plugin == 'Y')
+      puts 'Copying the plugin'
       mkdir_p "#{server_dir}/go-server-#{v}/plugins/external/"
       cp "#{setup.plugin_src_dir}", "#{server_dir}/go-server-#{v}/plugins/external/"
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,4 +1,4 @@
-require './lib/configuration.rb' 
+require './lib/configuration.rb'
 describe "Configuration" do
   describe Configuration::SetUp do
     before(:each) do
@@ -79,6 +79,10 @@ describe "Configuration" do
       expect(@setup.plugin_src_dir.to_s).to eq('sample/plugin/dir')
     end
 
+    it 'defauts to N for INCLUDE_PLUGIN' do
+      expect(@setup.include_plugin.to_s).to eq('N')
+    end
+
     it 'sets the AGENTS_INSTALL_DIR' do
       ENV['AGENTS_INSTALL_DIR'] = '/tmp'
       expect(@setup.agents_install_dir.to_s).to eq('/tmp/go-agents')
@@ -90,7 +94,7 @@ describe "Configuration" do
     end
 
     it 'generates git repo names based on the number of pipelines' do
-      ENV['NO_OF_PIPELINES'] ='3' 
+      ENV['NO_OF_PIPELINES'] ='3'
       expect(@setup.git_repos).to eq(['gitrepos/git-repo-1', 'gitrepos/git-repo-2', 'gitrepos/git-repo-3'])
     end
     it 'sets the jmeter directory' do
@@ -111,7 +115,7 @@ describe "Configuration" do
       expect(@server.base_url).to eq('http://goserver:8153')
     end
     it "sets the server base url from SERVER and PORT environment variables" do
-      ENV['GOCD_HOST'] = 'goserver' 
+      ENV['GOCD_HOST'] = 'goserver'
       ENV['GO_SERVER_PORT'] = '8253'
       expect(@server.base_url).to eq('http://goserver:8253')
     end
@@ -127,7 +131,7 @@ describe "Configuration" do
       expect(@server.base_url).to eq('http://admin:badger@authenticated_url:8253')
     end
     it 'sets the secure port' do
-      ENV['GO_SERVER_SSL_PORT'] = '8254' 
+      ENV['GO_SERVER_SSL_PORT'] = '8254'
       expect(@server.secure_port).to eq('8254')
     end
     it 'sets the default secure port' do
@@ -136,7 +140,7 @@ describe "Configuration" do
     end
     it "sets the url" do
      ENV['AUTH'] = nil
-     ENV['GO_SERVER_PORT'] = '8153' 
+     ENV['GO_SERVER_PORT'] = '8153'
      ENV['GOCD_HOST'] = "host"
      expect(@server.url).to eq('http://host:8153/go')
     end
@@ -146,13 +150,13 @@ describe "Configuration" do
       ENV['GO_SERVER_SSL_PORT']= 'secureport'
       ENV['SERVER_MEM']= 'memory'
       ENV['SERVER_MAX_MEM']= 'max_memory'
-      expect(@server.environment).to eq({ 
+      expect(@server.environment).to eq({
         "GO_SERVER_SYSTEM_PROPERTIES" => 'properties',
         "GO_SERVER_PORT" => 'port',
         "GO_SERVER_SSL_PORT" => 'secureport',
         "SERVER_MEM" => 'memory',
         "SERVER_MAX_MEM" => 'max_memory'
-      }) 
+      })
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -74,6 +74,11 @@ describe "Configuration" do
       expect(@setup.server_install_dir.to_s).to eq('go-server')
     end
 
+    it 'sets the PLUGIN_SRC_DIR' do
+      ENV['PLUGIN_SRC_DIR'] = 'sample/plugin/dir'
+      expect(@setup.plugin_src_dir.to_s).to eq('sample/plugin/dir')
+    end
+
     it 'sets the AGENTS_INSTALL_DIR' do
       ENV['AGENTS_INSTALL_DIR'] = '/tmp'
       expect(@setup.agents_install_dir.to_s).to eq('/tmp/go-agents')


### PR DESCRIPTION
By default, the plugin will not be used.  However, if you set the environmental variable INCLUDE_PLUGIN = Y and specify the parameter PLUGIN_SRC_DIR, the plugin will be copied over to plugins/external.