### PR TITLE
Make 2 separate tasks for new dashboard page load

### DIFF
--- a/rakelib/performance.rake
+++ b/rakelib/performance.rake
@@ -125,9 +125,14 @@ namespace :performance do
     loader.run 'pipeline_dashboard', "#{go_server.secure_url}/go"
   end
 
-  task new_dashboard_page: 'jmeter:prepare' do
+  task new_dashboard_page_using_access_token: 'jmeter:prepare' do
     loader = ScenarioLoader.new('./scenarios')
     loader.run_with_access_token 'new_pipeline_dashboard', "#{go_server.secure_url}/go"
+  end
+
+  task new_dashboard_page: 'jmeter:prepare' do
+    loader = ScenarioLoader.new('./scenarios')
+    loader.run 'new_pipeline_dashboard', "#{go_server.secure_url}/go"
   end
 
   task admin_pages: 'jmeter:prepare' do


### PR DESCRIPTION
One with access token another using basic auth - since we need to switch between runs for 19.1 and 19.2