### PR TITLE
Avoid cleaning up all containers and images

### DIFF
--- a/micro_performance/configuration.json
+++ b/micro_performance/configuration.json
@@ -1,4 +1,5 @@
 {
+    "gocd_server_image_name": "gocd/gocd-server-centos-7:v19.10.0",
     "test_duration": "1800",
     "pipelines": {
         "count": "10"

--- a/micro_performance/docker-compose.yml
+++ b/micro_performance/docker-compose.yml
@@ -2,6 +2,8 @@
 perfdb:
   build: db_setup
 
+  container_name: "perf_db"
+
   user: "root:root"
 
   environment:
@@ -10,7 +12,9 @@ perfdb:
 
 # Performance Go Server
 perfserver:
-  image: gocd/gocd-server-centos-7:v${GO_VERSION}
+  image: ${GOCD_SERVER_IMAGE}
+
+  container_name: "perf_server"
 
   links:
     - perfdb:db
@@ -28,8 +32,8 @@ perfserver:
     - ./server_setup:/godata
 
   ports:
-    - "8153:8153"
-    - "8154:8154"
+    - "8353:8153"
+    - "8354:8154"
 
   privileged: true
 
@@ -37,6 +41,8 @@ perfserver:
 # Agents and Repos container
 agents:
   image: centos:7
+
+  container_name: "perf_agents"
 
   links:
     - perfserver:perfserver
@@ -58,6 +64,8 @@ agents:
 repos:
   image: centos:7
 
+  container_name: "perf_repos"
+
   user: "root:root"
 
   command: ["./godata/init.sh"]
@@ -75,6 +83,8 @@ repos:
 # cAdvisor for monitoring - More info on how to send this data for storage - https://github.com/google/cadvisor/tree/master/docs/storage
 cadvisor:
   image: google/cadvisor
+
+  container_name: "cadvisor"
 
   ports:
     - "8080:8080"

--- a/micro_performance/lib/go_constants.rb
+++ b/micro_performance/lib/go_constants.rb
@@ -1,5 +1,5 @@
 module GoConstants
 
     AUTH_HEADER = "Basic #{Base64.encode64('admin:badger')}".freeze
-    BASE_URL = 'http://localhost:8153/go'.freeze
+    BASE_URL = 'http://localhost:8353/go'.freeze
 end

--- a/micro_performance/run.rb
+++ b/micro_performance/run.rb
@@ -19,6 +19,7 @@ def read_configuration
       f.puts("TOTAL_PIPELINES=#{configuration['pipelines']['count']}")
       f.puts("STATIC_AGENTS=#{configuration['agents']['static']['count']}")
       f.puts("PERF_TEST_DURATION=#{configuration['test_duration']}")
+      f.puts("GOCD_SERVER_IMAGE=#{configuration['gocd_server_image_name']}")
     end
 end
 
@@ -74,9 +75,9 @@ def create_jmx(scenario)
 end
 
 def cleanup_perf_setup
-    FileUtils.sh 'docker rm -f $(docker ps -q -a) || true'
-    FileUtils.sh ('docker rmi -f $(docker images -q) || true')
-    FileUtils.sh ('docker volume rm -f $(docker volume ls -q) || true')
+    ['perf_db', 'perf_server', 'perf_agents', 'perf_repos', 'cadvisor'].each do |container|
+      FileUtils.sh "docker rm -f -v #{container} || true"
+    end
 
     ['config', 'logs', 'plugins', 'artifacts', 'db'].each do |fldr|
         FileUtils.rm_rf "micro_performance/server_setup/#{fldr}" if Dir.exist? "micro_performance/server_setup/#{fldr}"


### PR DESCRIPTION
* Do clean up of only resources created by the test.
* Use unique port for perf server